### PR TITLE
Fix Genymotion launch script (Genymotion 2.10 and higher)

### DIFF
--- a/lib/help_run.js
+++ b/lib/help_run.js
@@ -428,9 +428,7 @@ class Helper {
 								// try to grab the last line from the file
 								lastLine = matches[matches.length - 1],
 								// capture the timestamp that is prefixed in the log per line
-								dateTime = lastLine.match(/^\d+-\d+-\d+T\d+:\d+:\d+Z/g),
-								// create a valid date string for Date.parse; need to add the current year after date
-								fullDateTime = `${dateTime[0]} ${new Date().getFullYear()} ${dateTime[1]}`;
+								dateTime = lastLine.match(/^\d+-\d+-\d+T\d+:\d+:\d+Z/g);
 
 							const
 								logTime = Date.parse(dateTime),

--- a/lib/help_run.js
+++ b/lib/help_run.js
@@ -420,24 +420,23 @@ class Helper {
 				}
 
 				fs.watchFile(playerLog, () => {
-					fs.createReadStream(playerLog)
-					.on('data', output => {
-						const matches = output.toString().trim().match(/\w+ \d+ \d+\:\d+\:\d+ .+/g);
+					var stream = new fs.createReadStream(playerLog);
+					stream.on('data', output => {
+						const matches = output.toString().trim().match(/\d+-\d+-\d+T\d+:\d+:\d+Z\ \[Genymotion Player:\d+\] \[\w+\] Device booted in .+/g);
 						if (matches) {
 							const
 								// try to grab the last line from the file
 								lastLine = matches[matches.length - 1],
 								// capture the timestamp that is prefixed in the log per line
-								dateTime = lastLine.match(/^\w+ \d+|\d+\:\d+\:\d+/g),
+								dateTime = lastLine.match(/^\d+-\d+-\d+T\d+:\d+:\d+Z/g),
 								// create a valid date string for Date.parse; need to add the current year after date
 								fullDateTime = `${dateTime[0]} ${new Date().getFullYear()} ${dateTime[1]}`;
 
 							const
-								logTime = Date.parse(fullDateTime),
+								logTime = Date.parse(dateTime),
 								deltaTime = Date.now() - logTime;
-
-							// if the timestamp is within 10 second of current time and log ends with 'Connected' (launched), then move to next task
-							if (deltaTime <= 10000 && /Connected$/g.test(lastLine)) {
+							// if the timestamp is within 10 second of current time and log ends with 'Device booted in' (launched), then move to next task
+							if (deltaTime <= 10000 && /Device booted in .+/g.test(lastLine)) {
 								fs.unwatchFile(playerLog);
 								resolve();
 							}


### PR DESCRIPTION
When I started to use the appium-tests project, I found that the Genymotion emulators launched, but the install of the app was never triggered.

The script was waiting for "Connected" on the last line of the logs, but it does not happen now with the latest Genymotion versions.

Only "Device booted in X ms" can be track and not open the last line because Genymotion emulators log more things after it has booted.